### PR TITLE
Adjusments to run Atlas.Statement with PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,100 @@
+name: Atlas.Statement CI
+
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+  workflow_dispatch:
+
+env:
+  fail-fast: true
+
+  # PHP extensions required by Composer
+  EXTENSIONS: pdo
+
+permissions:
+  contents: read
+
+jobs:
+
+#  # PHPStan
+#  quality:
+#    name: "Validate Quality"
+#    if: "!contains(github.event.head_commit.message, 'ci skip')"
+#
+#    permissions:
+#      contents: read
+#
+#    runs-on: ubuntu-22.04
+#
+#    strategy:
+#      fail-fast: true
+#      matrix:
+#        php:
+#          - '8.0'
+#          - '8.1'
+#          - '8.2'
+#          - '8.3'
+#          - '8.4'
+#    steps:
+#      - uses: actions/checkout@v4
+#
+#      - name: "Setup PHP"
+#        uses: shivammathur/setup-php@2.35.3
+#        with:
+#          php-version: ${{ matrix.php }}
+#          extensions: ${{ env.EXTENSIONS }}
+#        env:
+#          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#
+#      - name: "Install development dependencies with Composer"
+#        uses: "ramsey/composer-install@v3"
+#        with:
+#          composer-options: "--prefer-dist"
+#
+#      - name: "PHPStan"
+#        run: |
+#          composer stan
+
+  unit-tests:
+#    needs: quality
+
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+
+    name: Unit tests / PHP-${{ matrix.php }}
+    runs-on: ubuntu-22.04
+
+    strategy:
+      matrix:
+        php:
+          - '8.0'
+          - '8.1'
+          - '8.2'
+          - '8.3'
+          - '8.4'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Setup PHP"
+        uses: shivammathur/setup-php@2.35.3
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ env.EXTENSIONS }}
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Install development dependencies with Composer"
+        uses: "ramsey/composer-install@v3"
+        with:
+          composer-options: "--prefer-dist"
+
+      - name: "Run Unit Tests"
+        if: always()
+        run: |
+          composer test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /composer.lock
 /vendor
 /.phpunit.result.cache
+.bash_history
+.composer

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: php
-php:
-  - '7.1'
-  - '7.2'
-  - '7.3'
-  - '7.4'
-install: composer install

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -51,7 +51,7 @@ abstract class Statement
         }
     }
 
-    public function bindInline(mixed $value, int $type = null) : string
+    public function bindInline(mixed $value, ?int $type = null) : string
     {
         return $this->bind->inline($value, $type);
     }
@@ -61,7 +61,7 @@ abstract class Statement
         return $this->bind->sprintf($format, ...$values);
     }
 
-    public function bindValue(string $key, mixed $value, int $type = null) : static
+    public function bindValue(string $key, mixed $value, ?int $type = null) : static
     {
         $this->bind->value($key, $value, $type);
         return $this;

--- a/tests/DeleteTest.php
+++ b/tests/DeleteTest.php
@@ -10,7 +10,7 @@ namespace Atlas\Statement;
 
 use PDO;
 
-class DeleteTest extends StatementTest
+class DeleteTest extends StatementTestCase
 {
     public function testCommon()
     {

--- a/tests/InsertTest.php
+++ b/tests/InsertTest.php
@@ -10,7 +10,7 @@ namespace Atlas\Statement;
 
 use PDO;
 
-class InsertTest extends StatementTest
+class InsertTest extends StatementTestCase
 {
     public function testCommon()
     {

--- a/tests/SelectTest.php
+++ b/tests/SelectTest.php
@@ -11,7 +11,7 @@ namespace Atlas\Statement;
 use PDO;
 use Atlas\Statement\Driver\FakeDriver;
 
-class SelectTest extends StatementTest
+class SelectTest extends StatementTestCase
 {
     public function testDistinct()
     {

--- a/tests/StatementTestCase.php
+++ b/tests/StatementTestCase.php
@@ -9,10 +9,11 @@
 namespace Atlas\Statement;
 
 use PDO;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Atlas\Statement\Driver\FakeDriver;
 
-abstract class StatementTest extends \PHPUnit\Framework\TestCase
+abstract class StatementTestCase extends TestCase
 {
     protected $statement;
 
@@ -23,7 +24,7 @@ abstract class StatementTest extends \PHPUnit\Framework\TestCase
         $rc = new ReflectionClass(Bind::CLASS);
         $rp = $rc->getProperty('instanceCount');
         $rp->setAccessible(true);
-        $rp->setValue(0);
+        $rp->setValue(null, 0);
 
         $this->statement = $this->newStatement();
     }

--- a/tests/UpdateTest.php
+++ b/tests/UpdateTest.php
@@ -10,7 +10,7 @@ namespace Atlas\Statement;
 
 use PDO;
 
-class UpdateTest extends StatementTest
+class UpdateTest extends StatementTestCase
 {
     public function testCommon()
     {


### PR DESCRIPTION
- Added GitHub Actions setup to run the tests
- Renamed `StatementTest` to `StatementTestCase` to stop warnings from phpunit
- Changed `Statement::bindInline(mixed $value, int $type = null)` to `bindInline(mixed $value, ?int $type = null)` (PHP 8.4)
- Changed `Statement::bindValue(string $key, mixed $value, int $type = null)` to `bindValue(string $key, mixed $value, ?int $type = null)` (PHP 8.4)
- Added a couple of entries to `.gitignore`